### PR TITLE
WIP: API to allow for SK-Payload crypto operations

### DIFF
--- a/src/payload.ts
+++ b/src/payload.ts
@@ -1902,14 +1902,94 @@ export class PayloadSK extends Payload {
   }
 
   /**
-   * Decrypts the encrypted data in the SK payload
+   * Decrypts the encrypted data in the SK payload.
+   *
+   * The decryptFunction should handle removing the IV, Padding and Integrity Checksum Data.
+   *
+   * This should be called after checking the Integrity Checksum Data (except for AEAD algorithms, which are
+   * self-checking).
+   *
+   * @param decryptFunction Function that takes a Buffer and returns a decrypted Buffer
+   * @returns {Payload[]} Array of decrypted Payloads
    * @public
-   * @returns {Buffer} Decrypted data
    */
-  public decrypt(): Buffer {
-    // Implement decryption logic here
-    return this.encryptedData;
+  public decrypt(decryptFunction: (data: Buffer) => Buffer): Payload[] {
+    if (this.encryptedData.length === 0) {
+      throw new Error("No encrypted data to decrypt - must contain at least the IV and the Integrity Checksum Data");
+    }
+
+    let nextPayload = this.nextPayload;
+    let offset = 0;
+    const payloads: Payload[] = [];
+
+    if (nextPayload === payloadType.NONE) {
+      return [];
+    }
+
+    // Decrypt data
+    const decryptedData = decryptFunction(this.encryptedData);
+    if (decryptedData.length === 0) {
+      return [];
+    }
+
+    let nextPayloadClass = payloadTypeMapping[nextPayload];
+    if (!nextPayloadClass) {
+      throw new Error(`Unknown payload type: ${nextPayload}`);
+    }
+
+    while (
+      offset < decryptedData.length &&
+      nextPayloadClass &&
+      nextPayload !== payloadType.NONE
+    ) {
+      // Validate we have enough data for the next payload
+      if (offset + 4 > decryptedData.length) {
+        throw new Error(
+          `Insufficient data for payload header at offset ${offset}`
+        );
+      }
+
+      const payload = nextPayloadClass.parse(
+        decryptedData.subarray(offset, decryptedData.length)
+      );
+
+      payloads.push(payload);
+      offset += payload.length;
+      nextPayload = payload.nextPayload;
+      nextPayloadClass = payloadTypeMapping[nextPayload];
+
+      // Validate payload length
+      if (offset > decryptedData.length) {
+        throw new Error(
+          `Payload length exceeds packet size. Offset: ${offset}, Packet size: ${decryptedData.length}`
+        );
+      }
+    }
+
+    return payloads;
   }
+
+  /**
+   * Encrypts data and sets it as the encrypted data in the SK payload. Should be called before serializing the IKE
+   * message, when the SK payload is included and is the last one in the message.
+   *
+   * Also sets the nextPayload in the SK payload as the type of the first payload inside the encrypted data. This is
+   * an exception to the rule, but the SK payload is always the last one in the message, to compensate.
+   *
+   * The encryptFunction should include pre-pending the IV, appending Padding and space for the Integrity Checksum Data.
+   *
+   * The Integrity Checksum Data bytes will have to be updated after the entire IKE message is serialized.
+   *
+   * @param payloads Array of Payloads to encrypt
+   * @param encryptFunction Function that takes a Buffer and returns an encrypted Buffer
+   * @public
+   */
+  public encrypt(payloads: Payload[], encryptFunction: (data: Buffer) => Buffer): void {
+    this.nextPayload = (payloads.length === 0) ? payloadType.NONE : payloads[0].type;
+    const inClearData = Buffer.concat(payloads.map(p => p.serialize()));
+    this.encryptedData = encryptFunction(inClearData);
+  }
+
 }
 
 /**

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -80,7 +80,7 @@ export enum encrId {
   // RESERVED = 0,
   ENCR_DES_IV64 = 1, // Deprecated by [RFC9395]
   ENCR_DES = 2, // [RFC2405] - Deprecated by [RFC8247]
-  ENCR_DES3 = 3, // [RFC2451]
+  ENCR_3DES = 3, // [RFC2451]
   ENCR_RC5 = 4, // [RFC2451] - Deprecated by [RFC9395]
   ENCR_IDEA = 5, // [RFC2451] - Deprecated by [RFC9395]
   ENCR_CAST = 6, // [RFC2451] - Deprecated by [RFC9395]
@@ -107,7 +107,7 @@ export enum encrId {
   ENCR_CAMELLIA_CCM_16 = 27, // [RFC5529] RFC[8247]
   ENCR_CHACHA20_POLY1305 = 28, // [RFC7634] [RFC8439]
   ENCR_AES_CCM_8_IIV = 29, // [RFC8750] - Not allowed for IKEv2
-  ENCR_AES_CCM_16_IIV = 30, // [RFC8750] - Not allowed for IKEv2
+  ENCR_AES_GCM_16_IIV = 30, // [RFC8750] - Not allowed for IKEv2
   ENCR_CHACHA20_POLY1305_IIV = 31, // [RFC8750] - Not allowed for IKEv2
   ENCR_KUZNYECHIK_MGM_KTREE = 32, // [RFC9227]
   ENCR_MAGMA_MGM_KTREE = 33, // [RFC9227]

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -421,7 +421,7 @@ export class Transform {
     return attributes;
   }
 
-  public get AttributeKeyLength(): number | undefined {
+  public get attributeKeyLength(): number | undefined {
     let keyLengthAttribute = this.attributes?.find(attr => attr.type === attributeType.KeyLength);
     if (keyLengthAttribute && keyLengthAttribute.value && keyLengthAttribute.value.length == 2) {
       return keyLengthAttribute.value.readUInt16BE(0);
@@ -429,7 +429,7 @@ export class Transform {
     return undefined;
   }
 
-  public set AttributeKeyLength(keyLength: number) {
+  public set attributeKeyLength(keyLength: number) {
     let keyLengthBuffer = Buffer.alloc(2);
     keyLengthBuffer.writeUInt16BE(keyLength, 0);
     let keyLengthAttribute = this.attributes?.find(attr => attr.type === attributeType.KeyLength);


### PR DESCRIPTION
Should add the following capabilities:
- for the rx path
  - verify the signature in the last bytes of the packet; would be called on the original packet buffer, after parsing and deciding that integrity protection is needed
  - decrypt a PayloadSK into Payload[]
- for the tx path
  - encrypt a Payload[] into PayloadSK
  - compute the signature on the whole message (encrypted PayloadSK and serialized) and update the last bytes of the packet; would be called after serializing a whole message, before sending it

This would take some generic functions as parameters, which should be defined as closures such that only the parameters relevant here would be needed, while others (e.g. keys, algorithm selection and configurations)  would be hidden from the implementation here.

 